### PR TITLE
Add CRUD operations for hotel objects

### DIFF
--- a/frontend/src/main/utils/hotelUtils.js
+++ b/frontend/src/main/utils/hotelUtils.js
@@ -1,0 +1,38 @@
+// get restaurants from local storage
+const get = () => {
+  // details omitted
+};
+
+const getById = (id) => {
+  // details omitted
+}
+
+// set restaurants in local storage
+const set = (restaurantCollection) => {
+  // details omitted
+};
+
+// add a restaurant to local storage
+const add = (restaurant) => {
+  // details omitted
+};
+
+// update a restaurant in local storage
+const update = (restaurant) => {
+  // details omitted
+};
+
+// delete a restaurant from local storage
+const del = (id) => {
+  // details omitted
+};
+
+const hotelUtils = {
+  get,
+  getById,
+  add,
+  update,
+  del
+};
+
+export { hotelUtils };

--- a/frontend/src/main/utils/hotelUtils.js
+++ b/frontend/src/main/utils/hotelUtils.js
@@ -1,30 +1,88 @@
-// get restaurants from local storage
+function setToDefault() {
+  const hotelCollection = { nextId: 1, hotels: [] };
+  return set(hotelCollection);
+}
+
+// get hotels from local storage
 const get = () => {
-  // details omitted
+  const value = localStorage.getItem("hotels");
+  if (value === undefined) {
+    return setToDefault();
+  }
+  const collection = JSON.parse(value);
+  if (collection === null) {
+    return setToDefault();
+  }
+
+  return collection;
 };
 
 const getById = (id) => {
-  // details omitted
-}
+  if (id === undefined) {
+    return { error: "id is a required parameter" };
+  }
 
-// set restaurants in local storage
-const set = (restaurantCollection) => {
-  // details omitted
+  const { hotels } = get();
+
+  const found = hotels.find((r) => r.id === id);
+  if (found === undefined) {
+    return { error: `hotel with id ${id} not found` };
+  }
+  return { hotel: found };
 };
 
-// add a restaurant to local storage
-const add = (restaurant) => {
-  // details omitted
+// set hotels in local storage
+const set = (hotelCollection) => {
+  localStorage.setItem("hotels", JSON.stringify(hotelCollection));
+  return hotelCollection;
 };
 
-// update a restaurant in local storage
-const update = (restaurant) => {
-  // details omitted
+// add a hotel to local storage
+const add = (hotel) => {
+  const hotelCollection = get();
+  hotel = { ...hotel, id: hotelCollection.nextId };
+  hotelCollection.nextId++;
+  hotelCollection.hotels.push(hotel);
+  set(hotelCollection);
+  return hotel;
 };
 
-// delete a restaurant from local storage
+// update a hotel in local storage
+const update = (hotel) => {
+  if (hotel === undefined) {
+    return { error: "hotel is a required parameter" };
+  }
+
+  const hotelCollection = get();
+  const { hotels } = hotelCollection;
+
+  const index = hotels.findIndex((r) => r.id === hotel.id);
+  if (index === -1) {
+    return { error: `hotel with id ${hotel.id} not found` };
+  }
+
+  hotels[index] = hotel;
+  set(hotelCollection);
+  return { hotelCollection };
+};
+
+// delete a hotel from local storage
 const del = (id) => {
-  // details omitted
+  if (id === undefined) {
+    return { error: "id is a required parameter" };
+  }
+
+  const hotelCollection = get();
+  const { hotels } = hotelCollection;
+
+  const index = hotels.findIndex((r) => r.id === id);
+  if (index === -1) {
+    return { error: `hotel with id ${id} not found` };
+  }
+
+  hotels.splice(index, 1);
+  set(hotelCollection);
+  return { hotelCollection };
 };
 
 const hotelUtils = {
@@ -32,7 +90,7 @@ const hotelUtils = {
   getById,
   add,
   update,
-  del
+  del,
 };
 
 export { hotelUtils };

--- a/frontend/src/tests/utils/hotelUtils.test.js
+++ b/frontend/src/tests/utils/hotelUtils.test.js
@@ -1,0 +1,236 @@
+import { hotelFixtures } from "../../fixtures/hotelFixtures";
+import { hotelUtils } from "../../main/utils/hotelUtils";
+
+describe("hotelUtils tests", () => {
+  const createGetItemMock = (returnValue) => (key) => {
+    if (key !== "hotel") {
+      throw new Error("Unexpected key: " + key);
+    }
+    return JSON.stringify(returnValue);
+  };
+
+  let getItemSpy, setItemSpy;
+
+  beforeEach(() => {
+    getItemSpy = jest.spyOn(Storage.prototype, "getItem");
+    setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    setItemSpy.mockImplementation(() => null);
+  });
+
+  describe("get", () => {
+    test.each([null, undefined])(
+      "When hotels is %p in local storage, should set to empty list",
+      (value) => {
+        getItemSpy.mockImplementation(createGetItemMock(value));
+
+        const result = hotelUtils.get();
+
+        const expected = { nextId: 1, hotels: [] };
+        expect(result).toEqual(expected);
+
+        expect(setItemSpy).toHaveBeenCalledWith(
+          "hotel",
+          JSON.stringify(expected)
+        );
+      }
+    );
+
+    test("When hotels is [] in local storage, should return []", () => {
+      getItemSpy.mockImplementation(createGetItemMock([]));
+
+      const result = hotelUtils.get();
+
+      const expected = { nextId: 1, hotels: [] };
+      expect(result).toEqual(expected);
+
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+
+    test("When hotels is JSON of three hotels, should return that JSON", () => {
+      const hotels = hotelFixtures.threeHotels;
+      const mockCollection = { nextId: 10, hotels };
+      getItemSpy.mockImplementation(createGetItemMock(mockCollection));
+
+      const result = hotelUtils.get();
+
+      expect(result).toEqual(mockCollection);
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getById", () => {
+    test("Check that getting a hotel by id works", () => {
+      // arrange
+      const hotels = hotelFixtures.threeHotels;
+      getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, hotels }));
+
+      const idToGet = hotels[1].id;
+
+      // act
+      const result = hotelUtils.getById(idToGet);
+
+      // assert
+      const expected = { hotel: hotels[1] };
+      expect(result).toEqual(expected);
+    });
+
+    test("Check that getting a non-existing hotel returns an error", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.getById(99);
+
+      // assert
+      const expectedError = `hotel with id 99 not found`;
+      expect(result).toEqual({ error: expectedError });
+    });
+
+    test("Check that an error is returned when id not passed", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.getById();
+
+      // assert
+      const expectedError = `id is a required parameter`;
+      expect(result).toEqual({ error: expectedError });
+    });
+  });
+  describe("add", () => {
+    test("Starting from [], check that adding one hotel works", () => {
+      // arrange
+      const hotel = hotelFixtures.oneHotel[0];
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 1, hotels: [] })
+      );
+
+      // act
+      const result = hotelUtils.add(hotel);
+
+      // assert
+      expect(result).toEqual(hotel);
+      expect(setItemSpy).toHaveBeenCalledWith(
+        "hotels",
+        JSON.stringify({ nextId: 2, hotels: hotelFixtures.oneHotel })
+      );
+    });
+  });
+
+  describe("update", () => {
+    test("Check that updating an existing hotel works", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+      const updatedHotel = {
+        ...threeHotels[0],
+        name: "Updated Name",
+      };
+      const threeHotelsUpdated = [updatedHotel, threeHotels[1], threeHotels[2]];
+
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.update(updatedHotel);
+
+      // assert
+      const expected = {
+        hotelCollection: { nextId: 5, hotels: threeHotelsUpdated },
+      };
+      expect(result).toEqual(expected);
+      expect(setItemSpy).toHaveBeenCalledWith(
+        "hotels",
+        JSON.stringify(expected.hotelCollection)
+      );
+    });
+    test("Check that updating an non-existing hotel returns an error", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      const updatedHotel = {
+        id: 99,
+        name: "Fake Name",
+        description: "Fake Description",
+      };
+
+      // act
+      const result = hotelUtils.update(updatedHotel);
+
+      // assert
+      const expectedError = `hotel with id 99 not found`;
+      expect(result).toEqual({ error: expectedError });
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("del", () => {
+    test("Check that deleting a hotel by id works", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+      const idToDelete = threeHotels[1].id;
+      const threeHotelsUpdated = [threeHotels[0], threeHotels[2]];
+
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.del(idToDelete);
+
+      // assert
+
+      const expected = {
+        hotelCollection: { nextId: 5, hotels: threeHotelsUpdated },
+      };
+      expect(result).toEqual(expected);
+      expect(setItemSpy).toHaveBeenCalledWith(
+        "hotels",
+        JSON.stringify(expected.hotelCollection)
+      );
+    });
+    test("Check that deleting a non-existing hotel returns an error", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.del(99);
+
+      // assert
+      const expectedError = `hotel with id 99 not found`;
+      expect(result).toEqual({ error: expectedError });
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+    test("Check that an error is returned when id not passed", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.del();
+
+      // assert
+      const expectedError = `id is a required parameter`;
+      expect(result).toEqual({ error: expectedError });
+    });
+  });
+});

--- a/frontend/src/tests/utils/hotelUtils.test.js
+++ b/frontend/src/tests/utils/hotelUtils.test.js
@@ -3,7 +3,7 @@ import { hotelUtils } from "../../main/utils/hotelUtils";
 
 describe("hotelUtils tests", () => {
   const createGetItemMock = (returnValue) => (key) => {
-    if (key !== "hotel") {
+    if (key !== "hotels") {
       throw new Error("Unexpected key: " + key);
     }
     return JSON.stringify(returnValue);
@@ -30,14 +30,14 @@ describe("hotelUtils tests", () => {
         expect(result).toEqual(expected);
 
         expect(setItemSpy).toHaveBeenCalledWith(
-          "hotel",
+          "hotels",
           JSON.stringify(expected)
         );
       }
     );
 
     test("When hotels is [] in local storage, should return []", () => {
-      getItemSpy.mockImplementation(createGetItemMock([]));
+      getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, hotels: [] }));
 
       const result = hotelUtils.get();
 
@@ -174,6 +174,21 @@ describe("hotelUtils tests", () => {
       expect(result).toEqual({ error: expectedError });
       expect(setItemSpy).not.toHaveBeenCalled();
     });
+
+    test("Check that an error is returned when hotel not passed", () => {
+      // arrange
+      const threeHotels = hotelFixtures.threeHotels;
+      getItemSpy.mockImplementation(
+        createGetItemMock({ nextId: 5, hotels: threeHotels })
+      );
+
+      // act
+      const result = hotelUtils.update();
+
+      // assert
+      const expectedError = `hotel is a required parameter`;
+      expect(result).toEqual({ error: expectedError });
+    })
   });
 
   describe("del", () => {


### PR DESCRIPTION
In this PR, we add hotelUtils.js, containing the CRUD operations for hotels.

For the tests, compared to the restaurant example, I tried to reduce code duplication by extracting common parts into a `beforeEach` hook.