### PR TITLE
Add CRUD operations for movie objects

### DIFF
--- a/frontend/src/main/utils/movieUtils.js
+++ b/frontend/src/main/utils/movieUtils.js
@@ -1,0 +1,92 @@
+// get movies from local storage
+const get = () => {
+    const movieValue = localStorage.getItem("movies");
+    if (movieValue === undefined) {
+        const movieCollection = { nextId: 1, movies: [] }
+        return set(movieCollection);
+    }
+    const movieCollection = JSON.parse(movieValue);
+    if (movieCollection === null) {
+        const movieCollection = { nextId: 1, movies: [] }
+        return set(movieCollection);
+    }
+    return movieCollection;
+};
+
+const getById = (id) => {
+    if (id === undefined) {
+        return { "error": "id is a required parameter" };
+    }
+    const movieCollection = get();
+    const movies = movieCollection.movies;
+
+    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
+    const index = movies.findIndex((r) => r.id == id);
+    if (index === -1) {
+        return { "error": `movie with id ${id} not found` };
+    }
+    return { movie: movies[index] };
+}
+
+// set movies in local storage
+const set = (movieCollection) => {
+    localStorage.setItem("movies", JSON.stringify(movieCollection));
+    return movieCollection;
+};
+
+// add a movie to local storage
+const add = (movie) => {
+    const movieCollection = get();
+    movie = { ...movie, id: movieCollection.nextId };
+    movieCollection.nextId++;
+    movieCollection.movies.push(movie);
+    set(movieCollection);
+    return movie;
+};
+
+// update a movie in local storage
+const update = (movie) => {
+    const movieCollection = get();
+
+    const movies = movieCollection.movies;
+
+    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
+    const index = movies.findIndex((r) => r.id == movie.id);
+    if (index === -1) {
+        return { "error": `movie with id ${movie.id} not found` };
+    }
+    movies[index] = movie;
+    set(movieCollection);
+    return { movieCollection: movieCollection };
+};
+
+// delete a movie from local storage
+const del = (id) => {
+    if (id === undefined) {
+        return { "error": "id is a required parameter" };
+    }
+    const movieCollection = get();
+    const movies = movieCollection.movies;
+
+    /* eslint-disable-next-line eqeqeq */ // we really do want == here, not ===
+    const index = movies.findIndex((r) => r.id == id);
+    if (index === -1) {
+        return { "error": `movie with id ${id} not found` };
+    }
+    movies.splice(index, 1);
+    set(movieCollection);
+    return { movieCollection: movieCollection };
+};
+
+const movieUtils = {
+    get,
+    getById,
+    add,
+    update,
+    del
+};
+
+export { movieUtils };
+
+
+

--- a/frontend/src/tests/utils/movieUtils.test.js
+++ b/frontend/src/tests/utils/movieUtils.test.js
@@ -1,0 +1,290 @@
+import { movieFixtures } from "fixtures/movieFixtures";
+import { movieUtils } from "main/utils/movieUtils";
+
+describe("movieUtils tests", () => {
+    // return a function that can be used as a mock implementation of getItem
+    // the value passed in will be convertd to JSON and returned as the value
+    // for the key "movies".  Any other key results in an error
+    const createGetItemMock = (returnValue) => (key) => {
+        if (key === "movies") {
+            return JSON.stringify(returnValue);
+        } else {
+            throw new Error("Unexpected key: " + key);
+        }
+    };
+
+    describe("get", () => {
+
+        test("When movies is undefined in local storage, should set to empty list", () => {
+
+            // arrange
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock(undefined));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.get();
+
+            // assert
+            const expected = { nextId: 1, movies: [] } ;
+            expect(result).toEqual(expected);
+
+            const expectedJSON = JSON.stringify(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("movies", expectedJSON);
+        });
+
+        test("When movies is null in local storage, should set to empty list", () => {
+
+            // arrange
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock(null));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.get();
+
+            // assert
+            const expected = { nextId: 1, movies: [] } ;
+            expect(result).toEqual(expected);
+
+            const expectedJSON = JSON.stringify(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("movies", expectedJSON);
+        });
+
+        test("When movies is [] in local storage, should return []", () => {
+
+            // arrange
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, movies: [] }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.get();
+
+            // assert
+            const expected = { nextId: 1, movies: [] };
+            expect(result).toEqual(expected);
+
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+
+        test("When movies is JSON of three movies, should return that JSON", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+            const mockmovieCollection = { nextId: 10, movies: threemovies };
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock(mockmovieCollection));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.get();
+
+            // assert
+            expect(result).toEqual(mockmovieCollection);
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+    });
+
+
+    describe("getById", () => {
+        test("Check that getting a movie by id works", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+            const idToGet = threemovies[1].id;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            // act
+            const result = movieUtils.getById(idToGet);
+
+            // assert
+
+            const expected = { movie: threemovies[1] };
+            expect(result).toEqual(expected);
+        });
+
+        test("Check that getting a non-existing movie returns an error", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            // act
+            const result = movieUtils.getById(99);
+
+            // assert
+            const expectedError = `movie with id 99 not found`
+            expect(result).toEqual({ error: expectedError });
+        });
+
+        test("Check that an error is returned when id not passed", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            // act
+            const result = movieUtils.getById();
+
+            // assert
+            const expectedError = `id is a required parameter`
+            expect(result).toEqual({ error: expectedError });
+        });
+
+    });
+    describe("add", () => {
+        test("Starting from [], check that adding one movie works", () => {
+
+            // arrange
+            const movie = movieFixtures.onemovie[0];
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, movies: [] }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.add(movie);
+
+            // assert
+            expect(result).toEqual(movie);
+            expect(setItemSpy).toHaveBeenCalledWith("movies",
+                JSON.stringify({ nextId: 2, movies: movieFixtures.onemovie }));
+        });
+    });
+
+    describe("update", () => {
+        test("Check that updating an existing movie works", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+            const updatedmovie = {
+                ...threemovies[0],
+                name: "Updated Name"
+            };
+            const threemoviesUpdated = [
+                updatedmovie,
+                threemovies[1],
+                threemovies[2]
+            ];
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.update(updatedmovie);
+
+            // assert
+            const expected = { movieCollection: { nextId: 5, movies: threemoviesUpdated } };
+            expect(result).toEqual(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("movies", JSON.stringify(expected.movieCollection));
+        });
+        test("Check that updating an non-existing movie returns an error", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            const updatedmovie = {
+                id: 99,
+                name: "Fake Name",
+                description: "Fake Description"
+            }
+
+            // act
+            const result = movieUtils.update(updatedmovie);
+
+            // assert
+            const expectedError = `movie with id 99 not found`
+            expect(result).toEqual({ error: expectedError });
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("del", () => {
+        test("Check that deleting a movie by id works", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+            const idToDelete = threemovies[1].id;
+            const threemoviesUpdated = [
+                threemovies[0],
+                threemovies[2]
+            ];
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.del(idToDelete);
+
+            // assert
+
+            const expected = { movieCollection: { nextId: 5, movies: threemoviesUpdated } };
+            expect(result).toEqual(expected);
+            expect(setItemSpy).toHaveBeenCalledWith("movies", JSON.stringify(expected.movieCollection));
+        });
+        test("Check that deleting a non-existing movie returns an error", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+            setItemSpy.mockImplementation((_key, _value) => null);
+
+            // act
+            const result = movieUtils.del(99);
+
+            // assert
+            const expectedError = `movie with id 99 not found`
+            expect(result).toEqual({ error: expectedError });
+            expect(setItemSpy).not.toHaveBeenCalled();
+        });
+        test("Check that an error is returned when id not passed", () => {
+
+            // arrange
+            const threemovies = movieFixtures.threemovies;
+
+            const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+
+            // act
+            const result = movieUtils.del();
+
+            // assert
+            const expectedError = `id is a required parameter`
+            expect(result).toEqual({ error: expectedError });
+        });
+    });
+});
+

--- a/frontend/src/tests/utils/movieUtils.test.js
+++ b/frontend/src/tests/utils/movieUtils.test.js
@@ -77,8 +77,8 @@ describe("movieUtils tests", () => {
         test("When movies is JSON of three movies, should return that JSON", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
-            const mockmovieCollection = { nextId: 10, movies: threemovies };
+            const threeMovies = movieFixtures.threeMovies;
+            const mockmovieCollection = { nextId: 10, movies: threeMovies };
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
             getItemSpy.mockImplementation(createGetItemMock(mockmovieCollection));
@@ -100,28 +100,28 @@ describe("movieUtils tests", () => {
         test("Check that getting a movie by id works", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
-            const idToGet = threemovies[1].id;
+            const threeMovies = movieFixtures.threeMovies;
+            const idToGet = threeMovies[1].id;
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             // act
             const result = movieUtils.getById(idToGet);
 
             // assert
 
-            const expected = { movie: threemovies[1] };
+            const expected = { movie: threeMovies[1] };
             expect(result).toEqual(expected);
         });
 
         test("Check that getting a non-existing movie returns an error", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
+            const threeMovies = movieFixtures.threeMovies;
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             // act
             const result = movieUtils.getById(99);
@@ -134,10 +134,10 @@ describe("movieUtils tests", () => {
         test("Check that an error is returned when id not passed", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
+            const threeMovies = movieFixtures.threeMovies;
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             // act
             const result = movieUtils.getById();
@@ -152,7 +152,7 @@ describe("movieUtils tests", () => {
         test("Starting from [], check that adding one movie works", () => {
 
             // arrange
-            const movie = movieFixtures.onemovie[0];
+            const movie = movieFixtures.oneMovie[0];
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
             getItemSpy.mockImplementation(createGetItemMock({ nextId: 1, movies: [] }));
 
@@ -165,7 +165,7 @@ describe("movieUtils tests", () => {
             // assert
             expect(result).toEqual(movie);
             expect(setItemSpy).toHaveBeenCalledWith("movies",
-                JSON.stringify({ nextId: 2, movies: movieFixtures.onemovie }));
+                JSON.stringify({ nextId: 2, movies: movieFixtures.oneMovie }));
         });
     });
 
@@ -173,19 +173,19 @@ describe("movieUtils tests", () => {
         test("Check that updating an existing movie works", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
+            const threeMovies = movieFixtures.threeMovies;
             const updatedmovie = {
-                ...threemovies[0],
+                ...threeMovies[0],
                 name: "Updated Name"
             };
-            const threemoviesUpdated = [
+            const threeMoviesUpdated = [
                 updatedmovie,
-                threemovies[1],
-                threemovies[2]
+                threeMovies[1],
+                threeMovies[2]
             ];
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
             setItemSpy.mockImplementation((_key, _value) => null);
@@ -194,17 +194,17 @@ describe("movieUtils tests", () => {
             const result = movieUtils.update(updatedmovie);
 
             // assert
-            const expected = { movieCollection: { nextId: 5, movies: threemoviesUpdated } };
+            const expected = { movieCollection: { nextId: 5, movies: threeMoviesUpdated } };
             expect(result).toEqual(expected);
             expect(setItemSpy).toHaveBeenCalledWith("movies", JSON.stringify(expected.movieCollection));
         });
         test("Check that updating an non-existing movie returns an error", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
+            const threeMovies = movieFixtures.threeMovies;
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
             setItemSpy.mockImplementation((_key, _value) => null);
@@ -230,15 +230,15 @@ describe("movieUtils tests", () => {
         test("Check that deleting a movie by id works", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
-            const idToDelete = threemovies[1].id;
-            const threemoviesUpdated = [
-                threemovies[0],
-                threemovies[2]
+            const threeMovies = movieFixtures.threeMovies;
+            const idToDelete = threeMovies[1].id;
+            const threeMoviesUpdated = [
+                threeMovies[0],
+                threeMovies[2]
             ];
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
             setItemSpy.mockImplementation((_key, _value) => null);
@@ -248,17 +248,17 @@ describe("movieUtils tests", () => {
 
             // assert
 
-            const expected = { movieCollection: { nextId: 5, movies: threemoviesUpdated } };
+            const expected = { movieCollection: { nextId: 5, movies: threeMoviesUpdated } };
             expect(result).toEqual(expected);
             expect(setItemSpy).toHaveBeenCalledWith("movies", JSON.stringify(expected.movieCollection));
         });
         test("Check that deleting a non-existing movie returns an error", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
+            const threeMovies = movieFixtures.threeMovies;
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
             setItemSpy.mockImplementation((_key, _value) => null);
@@ -274,10 +274,10 @@ describe("movieUtils tests", () => {
         test("Check that an error is returned when id not passed", () => {
 
             // arrange
-            const threemovies = movieFixtures.threemovies;
+            const threeMovies = movieFixtures.threeMovies;
 
             const getItemSpy = jest.spyOn(Storage.prototype, 'getItem');
-            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threemovies }));
+            getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, movies: threeMovies }));
 
             // act
             const result = movieUtils.del();

--- a/frontend/src/tests/utils/movieUtils.test.js
+++ b/frontend/src/tests/utils/movieUtils.test.js
@@ -212,7 +212,8 @@ describe("movieUtils tests", () => {
             const updatedmovie = {
                 id: 99,
                 name: "Fake Name",
-                description: "Fake Description"
+                synopsis: "Fake Synopsis",
+                cast: "Fake Cast"
             }
 
             // act


### PR DESCRIPTION
Adds movieUtils.js for CRUD operations on movies.
Depends on #6, so we should probably wait until that is merged first because the tests fail.

Closes #5 