### PR TITLE
Let hotelUtils.getById accept id as a string

### DIFF
--- a/frontend/src/main/utils/hotelUtils.js
+++ b/frontend/src/main/utils/hotelUtils.js
@@ -22,6 +22,10 @@ const getById = (id) => {
     return { error: "id is a required parameter" };
   }
 
+  // convert id from possibly a string to number
+  // this is better than using double equals (==)
+  id = Number(id)
+
   const { hotels } = get();
 
   const found = hotels.find((r) => r.id === id);

--- a/frontend/src/tests/utils/hotelUtils.test.js
+++ b/frontend/src/tests/utils/hotelUtils.test.js
@@ -75,6 +75,21 @@ describe("hotelUtils tests", () => {
       expect(result).toEqual(expected);
     });
 
+    test("Check that getting a hotel by id works when id is a string", () => {
+      // arrange
+      const hotels = hotelFixtures.threeHotels;
+      getItemSpy.mockImplementation(createGetItemMock({ nextId: 5, hotels }));
+
+      const idToGet = hotels[1].id;
+
+      // act
+      const result = hotelUtils.getById(idToGet.toString());
+
+      // assert
+      const expected = { hotel: hotels[1] };
+      expect(result).toEqual(expected);
+    })
+
     test("Check that getting a non-existing hotel returns an error", () => {
       // arrange
       const threeHotels = hotelFixtures.threeHotels;


### PR DESCRIPTION
This PR allows hotelUtils.getById to also accept id as a string, which is needed by the webpages.